### PR TITLE
Translate comments to English

### DIFF
--- a/PyQtInspect/_pqi_bundle/pqi_keyboard_hook_win.py
+++ b/PyQtInspect/_pqi_bundle/pqi_keyboard_hook_win.py
@@ -29,7 +29,7 @@ WM_KEYUP = 0x0101
 WM_SYSKEYDOWN = 0x0104
 WM_SYSKEYUP = 0x0105
 
-VK_F8 = 0x77  # 目前只使用F8键
+VK_F8 = 0x77  # Currently only the F8 key is used.
 
 
 WM_TO_TEXT = {

--- a/PyQtInspect/_pqi_bundle/pqi_monkey_qt.py
+++ b/PyQtInspect/_pqi_bundle/pqi_monkey_qt.py
@@ -189,11 +189,11 @@ def _internal_patch_qt(QtCore, qt_support_mode='auto'):
                 self.run = self._pqi_exec_run
             else:
                 # MUST ADD PREFIX '_pqi_' to the method name, otherwise it will cause infinite recursion
-                # 如果使用和pydevd相同的变量名
-                # 则根据继承关系 QThead的子类 -> QThreadWrapper in pqi -> QThreadWrapper in pydevd -> QThread
-                # pqi中的self._pqi_original_run会指向pydevd中的self.run,
-                # 而此时self.run已经被pqi中的self._pqi_new_run(in pqi!!! pqi层的QThreadWrapper同名方法覆盖了pydevd层的方法)替换
-                # 因此会无限递归pqi层面的QThreadWrapper的self._pqi_new_run方法
+                # If we use the same variable names as pydevd,
+                # the inheritance chain becomes: QThread subclass -> QThreadWrapper in PyQtInspect -> QThreadWrapper in pydevd -> QThread.
+                # In that case, self._pqi_original_run in PyQtInspect would point to pydevd's self.run,
+                # but self.run has already been replaced by PyQtInspect's self._pqi_new_run (the PyQtInspect-level QThreadWrapper overrides the method in pydevd),
+                # leading the PyQtInspect QThreadWrapper to recurse infinitely into self._pqi_new_run.
                 self._pqi_original_run = self.run
                 self.run = self._pqi_new_run
             self._original_started = self.started
@@ -274,13 +274,14 @@ def _internal_patch_qt(QtCore, qt_support_mode='auto'):
             if self._pqi_original_program is None or self._pqi_original_arguments is None:
                 # If the QProcess instance is reused, we need to restore the original program and arguments
                 # todo
-                # 如果复用, 则必须调用start、startDetached、open方法, 这种时候self._pqi_original_arguments都不会为None
-                # 且 self._pqi_original_program 和 self._pqi_original_arguments 可保证是原始的参数
-                # (都拦截到了, 且method3的调用前需要setProgram和setArguments方法)
+                # If the QProcess instance is reused, it must have invoked start, startDetached, or open,
+                # so self._pqi_original_arguments will never be None.
+                # In that scenario, self._pqi_original_program and self._pqi_original_arguments are guaranteed to hold the original parameters
+                # because we intercept them, and method3 requires setProgram and setArguments to be called beforehand.
                 #
-                # 没有复用，method3的调用有两个前提情况
-                # 前面调用过setProgram、setArguments方法: self._pqi_original_program和self._pqi_original_arguments都不为None
-                # 没有调用: 则self._pqi_original_program和self._pqi_original_arguments都为None, 这里会调用原始的program和arguments方法
+                # Without reuse, method3 has two prerequisite situations:
+                # - If setProgram and setArguments were called earlier, both self._pqi_original_program and self._pqi_original_arguments are not None.
+                # - If they were not called, both attributes remain None, and we fall back to the original program and arguments methods here.
                 self._pqi_original_program = self._pqi_original_program_method()
                 self._pqi_original_arguments = self._pqi_original_arguments_method()
             arguments = [self._pqi_original_program] + self._pqi_original_arguments

--- a/PyQtInspect/_pqi_bundle/pqi_qt_tools.py
+++ b/PyQtInspect/_pqi_bundle/pqi_qt_tools.py
@@ -31,7 +31,7 @@ def _filter_trace_stack(traceStacks):
 
 
 # ==== TODO ====
-# 这个最好写个单元测试代码
+# Ideally, add a unit test for this helper.
 def find_name_in_mro(cls, name, default):
     """ Emulate _PyType_Lookup() in Objects/typeobject.c """
     for base in cls.__mro__:

--- a/PyQtInspect/_pqi_bundle/pqi_stack_tools.py
+++ b/PyQtInspect/_pqi_bundle/pqi_stack_tools.py
@@ -34,7 +34,7 @@ def getStackFrame(useGetFrame=True) -> typing.List[FrameInfo]:
                 line_no=frame.f_lineno,
                 func_name=frame.f_code.co_name
             )
-        ]  # 需要在创建期间获取stack就捕获行号, 否则后续的f_lineno会走到最后一行去
+        ]  # Capture the line number while constructing the stack; otherwise later f_lineno values point to the last line.
 
         while frame.f_back is not None:
             frames.append(

--- a/PyQtInspect/_pqi_bundle/pqi_structures.py
+++ b/PyQtInspect/_pqi_bundle/pqi_structures.py
@@ -25,8 +25,8 @@ class QWidgetInfo:
     pos: tuple
 
     # === PARENTS ===
-    # 之所以拆分成两个列表, 是为了减少传输的JSON数据量
-    # TODO: 评估下, 使用嵌套dataclass? namedtuple?
+    # Split into two lists to reduce the size of the JSON payload.
+    # TODO: Evaluate using nested dataclasses or namedtuples.
     # The parent classes of the QWidget.
     parent_classes: list
 

--- a/PyQtInspect/pqi_gui/children_menu_widget.py
+++ b/PyQtInspect/pqi_gui/children_menu_widget.py
@@ -24,7 +24,7 @@ class ChildrenMenuWidget(QWidget):
         super().__init__(parent)
 
         self.setObjectName("MenuWidget")
-        self._menu = menu  # 需要保存menu, 用于设置数据时调整menu的大小
+        self._menu = menu  # Retain the menu so we can resize it when the data changes.
         # self.resize(217, 289)
 
         self.verticalLayout = QtWidgets.QVBoxLayout(self)
@@ -95,13 +95,13 @@ class ChildrenMenuWidget(QWidget):
     def onListViewClicked(self, index):
         widgetId = index.data(Qt.UserRole + 1)
         if widgetId is None:
-            widgetId = -1  # loading项的id为-1, 由外部处理点击事件(需要隐藏的)
+            widgetId = -1  # The loading item uses id -1; the caller handles the click and should hide it.
         self.sigClickChild.emit(widgetId)
 
     def onListViewEntered(self, index):
         widgetId = index.data(Qt.UserRole + 1)
         if widgetId is None:
-            widgetId = -1  # loading项的id为-1, 由外部处理点击事件(需要隐藏的)
+            widgetId = -1  # The loading item uses id -1; the caller handles the hover and should hide it.
         self.sigHoverChild.emit(widgetId)
 
     def leaveEvent(self, event):

--- a/PyQtInspect/pqi_gui/hierarchy_bar.py
+++ b/PyQtInspect/pqi_gui/hierarchy_bar.py
@@ -90,7 +90,7 @@ class HierarchyItem(QPushButton):
             painter.setFont(self.m_font)
             painter.drawText(QRect(0, 0, self._textWidth, ITEM_HEIGHT), Qt.AlignCenter, self._text)
 
-        # 绘制箭头
+        # Draw the arrow.
         if self._menuShowed:
             painter.drawPixmap(QRect(self._textWidth, 0, ARROW_WIDTH, ITEM_HEIGHT), self.m_checkedIcon,
                                self.m_checkedIcon.rect())
@@ -123,7 +123,7 @@ class HierarchyItem(QPushButton):
     def enterEvent(self, event):
         self._moveFlag = True
         self.update()
-        self._barWidget.notifyItemHovered(self)  # 向上层通知鼠标进入
+        self._barWidget.notifyItemHovered(self)  # Notify the parent widget that the mouse entered.
 
     def leaveEvent(self, event):
         self._moveFlag = False
@@ -160,7 +160,7 @@ class HierarchyBarScrollArea(QtWidgets.QScrollArea):
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
 
     def wheelEvent(self, event):
-        # 响应鼠标滚轮事件, 倒置事件的坐标系, 使得横向滚动条也能滚动
+        # Handle wheel events by swapping the axes so the horizontal scroll bar can move.
         newEvent = QtGui.QWheelEvent(event.pos(), event.globalPos(),
                                      QtCore.QPoint(event.pixelDelta().y(), event.pixelDelta().x()),
                                      QtCore.QPoint(event.angleDelta().y(), event.angleDelta().x()),
@@ -184,7 +184,7 @@ class HierarchyBar(QtWidgets.QWidget):
 
         self._buttonGroup = QtWidgets.QButtonGroup(self)
         self._buttonGroup.setExclusive(True)
-        self._buttonGroup.buttonToggled.connect(self._onButtonToggled)  # 不能用clicked, 因为鼠标事件被拦截
+        self._buttonGroup.buttonToggled.connect(self._onButtonToggled)  # Cannot use clicked because mouse events are intercepted.
 
         self._mainLayout = QtWidgets.QHBoxLayout(self)
         self._mainLayout.setContentsMargins(0, 0, 0, 0)
@@ -288,8 +288,8 @@ class HierarchyBar(QtWidgets.QWidget):
 
         if self._buttonGroup.buttons():  # not empty, set last item checked by default
             lastItem = self._buttonGroup.buttons()[-1]
-            # 之所以在这里设置, 是因为避免数据变更后emit sigAncestorItemChanged信号
-            # 导致重复获取数据
+            # Set it here to avoid emitting sigAncestorItemChanged after the data changes
+            # and fetching the same information twice.
             self._curCheckedItem = lastItem
             lastItem.setChecked(True)
 
@@ -303,7 +303,7 @@ class HierarchyBar(QtWidgets.QWidget):
 
         self._menu.move(posX, posY)
         if self._widgetIdOfCurrMenu != itemWidget.getWidgetId():
-            # 脏数据
+            # Stale data.
             self._menuWidget.setLoading()
             self.sigReqChildWidgetsInfo.emit(itemWidget.getWidgetId())
         self._menu.show()
@@ -331,7 +331,7 @@ class HierarchyBar(QtWidgets.QWidget):
                     childObjNameList: typing.List[str],
                     childWidgetIdList: typing.List[int]):
         if self._curItemWithMenuShowed is None or widgetId != self._curItemWithMenuShowed.getWidgetId():
-            # 脏数据
+            # Stale data.
             return
 
         self._widgetIdOfCurrMenu = widgetId

--- a/PyQtInspect/pqi_gui/keyboard_hook_handler.py
+++ b/PyQtInspect/pqi_gui/keyboard_hook_handler.py
@@ -62,7 +62,7 @@ class WindowsKeyboardHookHandler(KeyboardHookHandler):
             kb_hook.grab(0x77, flag, lambda: self.sigDisableInspectKeyPressed.emit())
 
         thread = QtCore.QThread(self)
-        flag = GrabFlag()  # 可指示内部grab线程停止的标志, 用于解决GUI程序退出后grab线程仍无法退出的问题
+        flag = GrabFlag()  # Flag to stop the internal grab thread so it exits when the GUI terminates.
         thread.started.connect(_inSubThread)
         thread.stop_flag = flag
         return thread
@@ -77,7 +77,7 @@ class WindowsKeyboardHookHandler(KeyboardHookHandler):
 
     def _startKeyboardHookThread(self):
         # start keyboard hook thread if user wants to disable inspect by pressing F8
-        # TODO: 1) 自定义热键; 2) 当用户打开开关时, 且处于inspect, 立即运行线程
+        # TODO: 1) Support custom hotkeys; 2) When the user enables the switch during inspection, start the thread immediately.
         self._keyboardHookThread.stop_flag.clear_flag()
         self._keyboardHookThread.start()
 

--- a/PyQtInspect/pqi_gui/windows/attach_window.py
+++ b/PyQtInspect/pqi_gui/windows/attach_window.py
@@ -195,7 +195,7 @@ class AttachWindow(QtWidgets.QWidget):
         try:
             self._tryAttachToProcess(int(self._pidLine.getValue()))
         except ValueError:
-            # todo 如果pid不存在呢??
+            # TODO: What if the PID does not exist?
             QtWidgets.QMessageBox.critical(self, "Error", "Invalid Pid!")
             return
 
@@ -203,7 +203,7 @@ class AttachWindow(QtWidgets.QWidget):
         try:
             self._tryAttachToAllPySubprocess(int(self._pidLine.getValue()))
         except ValueError:
-            # todo 如果pid不存在呢??
+            # TODO: What if the PID does not exist?
             QtWidgets.QMessageBox.critical(self, "Error", "Invalid Pid!")
             return
 
@@ -215,7 +215,7 @@ class AttachWindow(QtWidgets.QWidget):
         self._thread.finished.connect(lambda: self._pidLine.setEnabled(True))
 
     def _tryAttachToProcess(self, pid: int):
-        """ Attach放在这个控件实现吧 """
+        """Keep the attach implementation within this widget."""
         if self._thread is not None and self._thread.isRunning():  # guard
             QtWidgets.QMessageBox.information(self, "Info", "Already Attaching")
             return

--- a/PyQtInspect/pqi_gui/workers/dispatcher.py
+++ b/PyQtInspect/pqi_gui/workers/dispatcher.py
@@ -42,9 +42,9 @@ class Dispatcher(QtCore.QThread):
         self.reader = None
         self.writer = None
 
-        # 由于dispatcher刚创建的时候, 主界面还来不及处理立即到来的信息(PQYWorker未发出新dispatcher创建的信号)
-        # 所以需要在主界面准备好之后再处理
-        # 此前的消息都缓存起来
+        # When the dispatcher is just created, the main UI may not yet be ready to process the incoming messages
+        # (PQYWorker has not emitted the signal that a new dispatcher is available).
+        # Buffer messages until the main UI is ready.
         self._mainUIReady = False
         self._msg_buffer = []
 

--- a/examples/imp.py
+++ b/examples/imp.py
@@ -2,31 +2,31 @@ import sys
 import multiprocessing
 
 StyleSheet = """
-/*这里是通用设置，所有按钮都有效，不过后面的可以覆盖这个*/
+/*These are general settings that apply to all buttons, but later definitions can override them.*/
 QPushButton {
-    border: none; /*去掉边框*/
+    border: none; /*Remove the border*/
 }
 
 /*
 QPushButton#xxx
-或者
+or
 #xx
-都表示通过设置的objectName来指定
+Both specify the button by its objectName.
 */
 QPushButton#RedButton {
-    background-color: #f44336; /*背景颜色*/
+    background-color: #f44336; /*Background color*/
 }
 #RedButton:hover {
-    background-color: #e57373; /*鼠标悬停时背景颜色*/
+    background-color: #e57373; /*Background color when the cursor hovers*/
 }
-/*注意pressed一定要放在hover的后面，否则没有效果*/
+/*Note that the pressed state must be declared after the hover state; otherwise it will not take effect.*/
 #RedButton:pressed {
-    background-color: #ffcdd2; /*鼠标按下不放时背景颜色*/
+    background-color: #ffcdd2; /*Background color while the mouse button remains pressed*/
 }
 
 #GreenButton {
     background-color: #4caf50;
-    border-radius: 5px; /*圆角*/
+    border-radius: 5px; /*Rounded corners*/
 }
 #GreenButton:hover {
     background-color: #81c784;
@@ -37,12 +37,12 @@ QPushButton#RedButton {
 
 #BlueButton {
     background-color: #2196f3;
-    /*限制最小最大尺寸*/
+    /*Constrain the minimum and maximum size*/
     min-width: 96px;
     max-width: 96px;
     min-height: 96px;
     max-height: 96px;
-    border-radius: 48px; /*圆形*/
+    border-radius: 48px; /*Circular*/
 }
 #BlueButton:hover {
     background-color: #64b5f6;
@@ -53,8 +53,8 @@ QPushButton#RedButton {
 
 #OrangeButton {
     max-height: 48px;
-    border-top-right-radius: 20px; /*右上角圆角*/
-    border-bottom-left-radius: 20px; /*左下角圆角*/
+    border-top-right-radius: 20px; /*Rounded top-right corner*/
+    border-bottom-left-radius: 20px; /*Rounded bottom-left corner*/
     background-color: #ff9800;
 }
 #OrangeButton:hover {
@@ -64,9 +64,9 @@ QPushButton#RedButton {
     background-color: #ffe0b2;
 }
 
-/*根据文字内容来区分按钮,同理还可以根据其它属性来区分*/
+/*Distinguish buttons by their text; likewise, other attributes can be used.*/
 QPushButton[text="purple button"] {
-    color: white; /*文字颜色*/
+    color: white; /*Text color*/
     background-color: #9c27b0;
 }
 """

--- a/examples/main_pyside2.py
+++ b/examples/main_pyside2.py
@@ -9,7 +9,7 @@
 # -*- coding: utf-8 -*-
 
 """
-Created on 2018年1月29日
+Created on January 29, 2018
 @author: Irony
 @site: https://pyqt.site , https://github.com/PyQt5
 @email: 892768447@qq.com
@@ -24,31 +24,31 @@ import multiprocessing
 from PySide2.QtWidgets import QWidget, QHBoxLayout, QPushButton, QApplication, QLabel
 
 StyleSheet = """
-/*这里是通用设置，所有按钮都有效，不过后面的可以覆盖这个*/
+/*These are general settings that apply to all buttons, but later definitions can override them.*/
 QPushButton {
-    border: none; /*去掉边框*/
+    border: none; /*Remove the border*/
 }
 
 /*
 QPushButton#xxx
-或者
+or
 #xx
-都表示通过设置的objectName来指定
+Both specify the button by its objectName.
 */
 QPushButton#RedButton {
-    background-color: #f44336; /*背景颜色*/
+    background-color: #f44336; /*Background color*/
 }
 #RedButton:hover {
-    background-color: #e57373; /*鼠标悬停时背景颜色*/
+    background-color: #e57373; /*Background color when the cursor hovers*/
 }
-/*注意pressed一定要放在hover的后面，否则没有效果*/
+/*Note that the pressed state must be declared after the hover state; otherwise it will not take effect.*/
 #RedButton:pressed {
-    background-color: #ffcdd2; /*鼠标按下不放时背景颜色*/
+    background-color: #ffcdd2; /*Background color while the mouse button remains pressed*/
 }
 
 #GreenButton {
     background-color: #4caf50;
-    border-radius: 5px; /*圆角*/
+    border-radius: 5px; /*Rounded corners*/
 }
 #GreenButton:hover {
     background-color: #81c784;
@@ -59,12 +59,12 @@ QPushButton#RedButton {
 
 #BlueButton {
     background-color: #2196f3;
-    /*限制最小最大尺寸*/
+    /*Constrain the minimum and maximum size*/
     min-width: 96px;
     max-width: 96px;
     min-height: 96px;
     max-height: 96px;
-    border-radius: 48px; /*圆形*/
+    border-radius: 48px; /*Circular*/
 }
 #BlueButton:hover {
     background-color: #64b5f6;
@@ -75,8 +75,8 @@ QPushButton#RedButton {
 
 #OrangeButton {
     max-height: 48px;
-    border-top-right-radius: 20px; /*右上角圆角*/
-    border-bottom-left-radius: 20px; /*左下角圆角*/
+    border-top-right-radius: 20px; /*Rounded top-right corner*/
+    border-bottom-left-radius: 20px; /*Rounded bottom-left corner*/
     background-color: #ff9800;
 }
 #OrangeButton:hover {
@@ -86,9 +86,9 @@ QPushButton#RedButton {
     background-color: #ffe0b2;
 }
 
-/*根据文字内容来区分按钮,同理还可以根据其它属性来区分*/
+/*Distinguish buttons by their text; likewise, other attributes can be used.*/
 QPushButton[text="purple button"] {
-    color: white; /*文字颜色*/
+    color: white; /*Text color*/
     background-color: #9c27b0;
 }
 """

--- a/examples/multi_buttons.py
+++ b/examples/multi_buttons.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
-Created on 2018年1月29日
+Created on January 29, 2018
 @author: Irony
 @site: https://pyqt.site , https://github.com/PyQt5
 @email: 892768447@qq.com


### PR DESCRIPTION
## Summary
- translate remaining non-English comments in example stylesheets and Qt helper modules to professional English equivalents
- clarify inline documentation in PyQtInspect GUI components, workers, and server logic to explain behavior in English
- update attach window, keyboard hook, and dispatcher comments for consistency while preserving meaning

## Testing
- python -m compileall PyQtInspect examples

------
https://chatgpt.com/codex/tasks/task_e_68cab130a508832a8f0ca6833b2c9add