### PR TITLE
[Enhancement] Add 'Configure IDE' button to error message box and implement common operators for cross-module interactions

### DIFF
--- a/PyQtInspect/pqi_gui/common_operators.py
+++ b/PyQtInspect/pqi_gui/common_operators.py
@@ -1,0 +1,30 @@
+# -*- encoding:utf-8 -*-
+# ==============================================
+# Author: Jeza Chen
+# Time: 2025/10/21 23:57
+# Description: Common operators for GUI, simplify the connection between modules
+# ==============================================
+from PyQt5 import QtCore
+
+
+class CommonOperators(QtCore.QObject):
+    _instance = None
+
+    sigOpenSettings = QtCore.pyqtSignal()
+
+    @classmethod
+    def instance(cls):
+        return cls._instance
+
+    @classmethod
+    def initInstance(cls, parent):
+        """ Initialize the singleton instance, this method MUST be called before `instance()`
+        :param parent: MUST be the main window
+        :return: the singleton instance
+        """
+        if cls._instance is None:
+            cls._instance = CommonOperators(parent)
+        return cls._instance
+
+    def openSettings(self):
+        self.sigOpenSettings.emit()

--- a/PyQtInspect/pqi_gui/tabs/create_stacks_list_widget.py
+++ b/PyQtInspect/pqi_gui/tabs/create_stacks_list_widget.py
@@ -3,6 +3,7 @@ import os
 from PyQt5 import QtWidgets, QtCore, QtGui
 
 from PyQtInspect._pqi_bundle import pqi_log
+from PyQtInspect.pqi_gui.common_operators import CommonOperators
 from PyQtInspect.pqi_gui.settings.ide_jumpers import jump_to_ide
 
 
@@ -13,6 +14,14 @@ class CreateStacksListWidget(QtWidgets.QListWidget):
         super().__init__(parent)
         self.setMinimumHeight(200)
         self.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
+
+        # Message box
+        self._messageBox = QtWidgets.QMessageBox(self)
+        self._messageBox.setIcon(QtWidgets.QMessageBox.Icon.Critical)
+        self._messageBox.setWindowTitle('Error')
+
+        self._messageBoxConfigureBtn = self._messageBox.addButton('Configure IDE', QtWidgets.QMessageBox.ButtonRole.ActionRole)
+        self._messageBoxOkBtn = self._messageBox.addButton('OK', QtWidgets.QMessageBox.ButtonRole.ActionRole)
 
     def setStacks(self, stacks: list):
         self.clear()
@@ -53,6 +62,9 @@ class CreateStacksListWidget(QtWidgets.QListWidget):
             jump_to_ide(fileName, lineNo)
         except Exception as e:
             pqi_log.error(f"Failed to jump to IDE: {e}")
-            # message box
-            QtWidgets.QMessageBox.critical(self, "Error", f"{e}")
+            # show message box
+            self._messageBox.setText(f"{e}")
+            self._messageBox.exec()
+            if self._messageBox.clickedButton() == self._messageBoxConfigureBtn:
+                CommonOperators.instance().openSettings()
 

--- a/PyQtInspect/pqi_server_gui.py
+++ b/PyQtInspect/pqi_server_gui.py
@@ -10,6 +10,7 @@ import typing
 import argparse
 import json
 
+from PyQtInspect.pqi_gui.common_operators import CommonOperators
 from PyQtInspect.pqi_gui.settings import SettingsController
 
 # ↑ DO NOT import PyQtInspect-specific modules before inserting the module path into sys.path.
@@ -310,7 +311,16 @@ class PQIWindow(QtWidgets.QMainWindow):
         self._curHighlightedWidgetId = -1
         # endregion
 
+        self._initCommonOperators()
+
         self.setStyleSheet(GLOBAL_STYLESHEET)
+
+    # region -- Common Operators --
+    def _initCommonOperators(self):
+        inst = CommonOperators.initInstance(self)
+        inst.sigOpenSettings.connect(self._openSettingWindow)
+
+    # endregion
 
     # region -- For always on top action --
     def _setAlwaysOnTop(self, on_top: bool):


### PR DESCRIPTION
This pull request introduces a new `CommonOperators` singleton class to centralize and simplify communication between GUI modules, particularly for triggering global actions like opening the settings window. The changes refactor error handling in the stacks list widget to use a custom message box with an action button, and integrate the new operator into the main server GUI for consistent settings management.

**Core architectural improvements:**

* Added `CommonOperators` singleton class in `common_operators.py` to provide a centralized mechanism for emitting signals (such as `sigOpenSettings`) and connecting global actions between GUI modules.

**Integration and refactoring:**

* Integrated `CommonOperators` into `create_stacks_list_widget.py` and `pqi_server_gui.py` by importing the new class and initializing the singleton in the main window, enabling signal-based communication for opening the settings window. [[1]](diffhunk://#diff-bed74e18cb6a9934f8a7960fb67e92e8a5cf68eefdf83852075b3e37b0f8f335R6) [[2]](diffhunk://#diff-7705913ca17906c3165a53495ab77167b2a45de6cd7822da7d5f171c730b539aR13) [[3]](diffhunk://#diff-7705913ca17906c3165a53495ab77167b2a45de6cd7822da7d5f171c730b539aR314-R324)

**User experience improvements:**

* Refactored error handling in `create_stacks_list_widget.py` to use a custom `QMessageBox` with "Configure IDE" and "OK" buttons, allowing users to directly open the settings window when IDE jump fails. [[1]](diffhunk://#diff-bed74e18cb6a9934f8a7960fb67e92e8a5cf68eefdf83852075b3e37b0f8f335R18-R25) [[2]](diffhunk://#diff-bed74e18cb6a9934f8a7960fb67e92e8a5cf68eefdf83852075b3e37b0f8f335L56-R69)