### PR TITLE
[Documentation] Update links to Chinese and English documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
 <a href="https://github.com/JezaChen/PyQtInspect-Open">Source Code</a> |
-<a href="https://jezachen.github.io/PyQtInspect-README-zh">中文文档</a> | 
+<a href="https://pyqtinspect.jeza.net/index_zh">中文文档</a> | 
 <a href="https://pypi.org/project/PyQtInspect/">PyPI</a>
 </p>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 
 <p align="center">
 <a href="https://github.com/JezaChen/PyQtInspect-Open">Source Code</a> |
-<a href="https://jezachen.github.io/PyQtInspect-README-zh">中文文档</a> | 
+<a href="/index_zh">中文文档</a> | 
 <a href="https://pypi.org/project/PyQtInspect/">PyPI</a>
 </p>
 

--- a/docs/index_zh.md
+++ b/docs/index_zh.md
@@ -6,7 +6,7 @@
 
 <p align="center">
 <a href="https://github.com/JezaChen/PyQtInspect-Open">源代码</a> |
-<a href="https://jeza-chen.com/PyqtInspect">英文文档</a> | 
+<a href="/">英文文档</a> | 
 <a href="https://pypi.org/project/PyQtInspect/">PyPI</a>
 </p>
 


### PR DESCRIPTION
This pull request updates documentation links to ensure they point to the correct resources and improve navigation between English and Chinese documentation. The changes affect the main project `README.md` and both English and Chinese documentation index files.

Documentation link updates:

* Updated the Chinese documentation link in `README.md` to point to the new site at `https://pyqtinspect.jeza.net/index_zh`.
* Changed the Chinese documentation link in `docs/index.md` to use a relative path (`/index_zh`) for easier navigation within the documentation site.
* Modified the English documentation link in `docs/index_zh.md` to use a relative path (`/`) instead of an external site, making it consistent with the new structure.