### PR TITLE
Replace hardcoded sys.platform checks with shared constants

### DIFF
--- a/PyQtInspect/_pqi_bundle/pqi_monkey.py
+++ b/PyQtInspect/_pqi_bundle/pqi_monkey.py
@@ -136,7 +136,7 @@ def is_python(path):
 
 
 def remove_quotes_from_args(args):
-    if sys.platform == "win32":
+    if IS_WINDOWS:
         new_args = []
         for x in args:
             if len(x) > 1 and x.startswith('"') and x.endswith('"'):
@@ -148,7 +148,7 @@ def remove_quotes_from_args(args):
 
 
 def quote_args(args):
-    if sys.platform == "win32":
+    if IS_WINDOWS:
         quoted_args = []
         for x in args:
             if x.startswith('"') and x.endswith('"'):

--- a/PyQtInspect/pqi_gui/keyboard_hook_handler.py
+++ b/PyQtInspect/pqi_gui/keyboard_hook_handler.py
@@ -16,8 +16,8 @@ class KeyboardHookHandler(QtCore.QObject):
     def __new__(cls, *args, **kwargs):
         """ Factory method to create a proper instance according to the platform. """
 
-        import sys
-        if sys.platform == 'win32':
+        from PyQtInspect._pqi_bundle.pqi_contants import IS_WINDOWS
+        if IS_WINDOWS:
             class_ = WindowsKeyboardHookHandler
         else:
             class_ = DummyKeyboardHookHandler

--- a/PyQtInspect/pqi_gui/keyboard_hook_handler.py
+++ b/PyQtInspect/pqi_gui/keyboard_hook_handler.py
@@ -8,6 +8,8 @@ import abc
 
 from PyQt5 import QtCore
 
+from PyQtInspect._pqi_bundle.pqi_contants import IS_WINDOWS
+
 
 class KeyboardHookHandler(QtCore.QObject):
     sigDisableInspectKeyPressed = QtCore.pyqtSignal()
@@ -16,7 +18,6 @@ class KeyboardHookHandler(QtCore.QObject):
     def __new__(cls, *args, **kwargs):
         """ Factory method to create a proper instance according to the platform. """
 
-        from PyQtInspect._pqi_bundle.pqi_contants import IS_WINDOWS
         if IS_WINDOWS:
             class_ = WindowsKeyboardHookHandler
         else:

--- a/PyQtInspect/pqi_gui/platform_specific/__init__.py
+++ b/PyQtInspect/pqi_gui/platform_specific/__init__.py
@@ -1,10 +1,9 @@
 import typing as _typing
 
 from . import _base
+from PyQtInspect._pqi_bundle.pqi_contants import IS_WINDOWS, IS_MACOS
 
 def _get_setup() -> _typing.Type[_base.Setup]:
-    from PyQtInspect._pqi_bundle.pqi_contants import IS_WINDOWS, IS_MACOS
-
     if IS_WINDOWS:
         from ._windows import WindowsSetup as PlatformSetup
     elif IS_MACOS:

--- a/PyQtInspect/pqi_gui/platform_specific/__init__.py
+++ b/PyQtInspect/pqi_gui/platform_specific/__init__.py
@@ -1,12 +1,13 @@
-import sys as _sys
 import typing as _typing
 
 from . import _base
 
 def _get_setup() -> _typing.Type[_base.Setup]:
-    if _sys.platform.startswith("win"):
+    from PyQtInspect._pqi_bundle.pqi_contants import IS_WINDOWS, IS_MACOS
+
+    if IS_WINDOWS:
         from ._windows import WindowsSetup as PlatformSetup
-    elif _sys.platform == "darwin":
+    elif IS_MACOS:
         from ._macos import MacOSSetup as PlatformSetup
     else:
         from ._base import DummySetup as PlatformSetup

--- a/PyQtInspect/pqi_gui/settings/ide_jumpers.py
+++ b/PyQtInspect/pqi_gui/settings/ide_jumpers.py
@@ -199,7 +199,7 @@ def _find_default_ide_path_helper(
         return ''
 
     # First, try to use terminal command to find the path
-    if sys.platform == 'win32':
+    if IS_WINDOWS:
         defaultPath = _find_for_windows()
         if defaultPath:
             pqi_log.info(f'Found IDE path for {command_name} from commands on Windows: {defaultPath}')

--- a/PyQtInspect/pqi_gui/styles.py
+++ b/PyQtInspect/pqi_gui/styles.py
@@ -1,8 +1,8 @@
 # -*- encoding:utf-8 -*-
+from PyQtInspect._pqi_bundle.pqi_contants import IS_WINDOWS, IS_MACOS
 
 
 def _get_default_font():
-    from PyQtInspect._pqi_bundle.pqi_contants import IS_WINDOWS, IS_MACOS
     if IS_WINDOWS:  # Windows
         return 'Microsoft Yahei'
     elif IS_MACOS:  # macOS

--- a/PyQtInspect/pqi_gui/styles.py
+++ b/PyQtInspect/pqi_gui/styles.py
@@ -2,10 +2,10 @@
 
 
 def _get_default_font():
-    import sys
-    if sys.platform == 'win32':  # Windows
+    from PyQtInspect._pqi_bundle.pqi_contants import IS_WINDOWS, IS_MACOS
+    if IS_WINDOWS:  # Windows
         return 'Microsoft Yahei'
-    elif sys.platform == 'darwin':  # macOS
+    elif IS_MACOS:  # macOS
         return 'Helvetica'
     else:  # Linux
         return 'DejaVu Sans'

--- a/PyQtInspect/pqi_gui/windows/attach_window.py
+++ b/PyQtInspect/pqi_gui/windows/attach_window.py
@@ -9,7 +9,7 @@ from PyQt5 import QtWidgets, QtGui, QtCore
 from PyQtInspect.pqi_gui._pqi_res import get_icon
 from PyQtInspect.pqi_gui.components.simple_kv_line_edit import SimpleSettingLineEdit
 import PyQtInspect.pqi_gui.data_center as DataCenter
-
+from PyQtInspect._pqi_bundle.pqi_contants import IS_WINDOWS
 
 PYTHON_NAMES = ['python', ]
 
@@ -52,8 +52,7 @@ class PidLineEdit(SimpleSettingLineEdit):
 
         @note: Only available on Windows.
         """
-        import sys
-        if sys.platform == "win32":
+        if IS_WINDOWS:
             def _tryGrab():
                 import wingrab
                 pid = wingrab.grab()

--- a/PyQtInspect/pqi_server_gui.py
+++ b/PyQtInspect/pqi_server_gui.py
@@ -10,6 +10,7 @@ import typing
 import argparse
 import json
 
+from PyQtInspect._pqi_bundle.pqi_contants import IS_MACOS
 from PyQtInspect.pqi_gui.common_operators import CommonOperators
 from PyQtInspect.pqi_gui.settings import SettingsController
 
@@ -930,7 +931,7 @@ def main():
     app.setWindowIcon(get_icon())
 
     # Use the fusion palette for macOS
-    if sys.platform == "darwin":
+    if IS_MACOS:
         style = QtWidgets.QStyleFactory.create("Fusion")
         if style:
             fusion_palette = style.standardPalette()


### PR DESCRIPTION
## Summary
- **Replace scattered `sys.platform` comparisons** across 7 modules with `IS_WINDOWS` / `IS_MACOS` constants from `pqi_contants.py`, establishing a single source of truth for platform detection.
- **Remove legacy code**: delete obsolete `_pqi_saved_modules.py` compatibility layer and unused packaging/launcher scripts (`pack_exe.py`, `pack_exe_pyinstaller.py`, `run_server.py`).

## Changed files
- `pqi_monkey.py` — use `IS_WINDOWS` in `remove_quotes_from_args` / `quote_args`
- `keyboard_hook_handler.py` — use `IS_WINDOWS` in factory `__new__`
- `platform_specific/__init__.py` — use `IS_WINDOWS` / `IS_MACOS` in `_get_setup()`
- `ide_jumpers.py` — use `IS_WINDOWS` in `_find_default_ide_path_helper`
- `styles.py` — use `IS_WINDOWS` / `IS_MACOS` in `_get_default_font`
- `attach_window.py` — use `IS_WINDOWS` in `PidLineEdit`
- `pqi_server_gui.py` — use `IS_MACOS` in `main()`

## Note
`pqi_attach/` still contains its own local `IS_WINDOWS`/`IS_MAC` definitions — these can be unified in a follow-up PR.

## Test plan
- [ ] Verify server GUI launches correctly on Windows
- [ ] Verify platform-specific code paths (font selection, keyboard hook, IDE detection) still work
- [ ] Spot-check that attach window grab button appears only on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)