### PR TITLE
[Refactor] Move get_fullname and get_package_dir to pqi_path_helper

### DIFF
--- a/PyQtInspect/_pqi_bundle/pqi_path_helper.py
+++ b/PyQtInspect/_pqi_bundle/pqi_path_helper.py
@@ -1,5 +1,7 @@
 # -*- encoding:utf-8 -*-
+import os
 import pathlib
+import sys
 
 __all__ = [
     'is_relative_to',
@@ -43,6 +45,29 @@ def find_pqi_module_path():
     result = str(path).replace('\\', '/')
     _PQI_MODULE_PATH_CACHE = result
     return result
+
+
+def get_fullname(mod_name):
+    import pkgutil
+
+    try:
+        loader = pkgutil.get_loader(mod_name)
+    except:
+        return None
+    if loader is not None:
+        for attr in ("get_filename", "_get_filename"):
+            meth = getattr(loader, attr, None)
+            if meth is not None:
+                return meth(mod_name)
+    return None
+
+
+def get_package_dir(mod_name):
+    for path in sys.path:
+        mod_path = os.path.join(path, mod_name.replace('.', '/'))
+        if os.path.isdir(mod_path):
+            return mod_path
+    return None
 
 
 # === FOR COMPILE ===

--- a/PyQtInspect/_pqi_bundle/pqi_path_helper.py
+++ b/PyQtInspect/_pqi_bundle/pqi_path_helper.py
@@ -6,6 +6,8 @@ import sys
 __all__ = [
     'is_relative_to',
     'find_pqi_module_path',
+    'get_fullname',
+    'get_package_dir',
     'find_compile_pqi_tool',
     'find_pqi_server_gui_entry',
 ]

--- a/PyQtInspect/pqi.py
+++ b/PyQtInspect/pqi.py
@@ -29,7 +29,7 @@ from PyQtInspect._pqi_bundle.pqi_typing import OptionalDict
 from PyQtInspect._pqi_bundle.pqi_structures import QWidgetInfo, QWidgetChildrenInfo
 from PyQtInspect._pqi_bundle import pqi_log
 from PyQtInspect._pqi_bundle.pqi_connect_tools import random_port
-from PyQtInspect._pqi_bundle.pqi_path_helper import find_pqi_server_gui_entry
+from PyQtInspect._pqi_bundle.pqi_path_helper import find_pqi_server_gui_entry, get_fullname, get_package_dir
 
 import traceback
 
@@ -114,29 +114,6 @@ def enable_qt_support(qt_support_mode, is_attach: bool = False):
         print(_QT_AUTO_DETECT_NOTIFICATION.replace("📢", ""))
 
     monkey_qt.patch_qt(qt_support_mode, is_attach)
-
-
-def get_fullname(mod_name):
-    import pkgutil
-
-    try:
-        loader = pkgutil.get_loader(mod_name)
-    except:
-        return None
-    if loader is not None:
-        for attr in ("get_filename", "_get_filename"):
-            meth = getattr(loader, attr, None)
-            if meth is not None:
-                return meth(mod_name)
-    return None
-
-
-def get_package_dir(mod_name):
-    for path in sys.path:
-        mod_path = os.path.join(path, mod_name.replace('.', '/'))
-        if os.path.isdir(mod_path):
-            return mod_path
-    return None
 
 
 def save_main_module(file, module_name):


### PR DESCRIPTION
This pull request refactors utility functions related to module path handling in the codebase. The main focus is to move the `get_fullname` and `get_package_dir` functions from `pqi.py` to `pqi_path_helper.py` for better code organization and reuse. Imports are updated accordingly to reflect this change.

**Refactoring and code organization:**

* Moved the `get_fullname` and `get_package_dir` utility functions from `pqi.py` to `pqi_path_helper.py` to centralize path-related helpers. [[1]](diffhunk://#diff-5fed4244482ec52c806522c96f54d2a52103fd91cab3cf57100a4e366a4b3ba3R50-R72) [[2]](diffhunk://#diff-72c2439d64e87177ebeaf81a3abc9c634141f26fd67de6f7c37748d1235b4b6eL119-L141)
* Updated imports in `pqi.py` to import `get_fullname` and `get_package_dir` from `pqi_path_helper.py` instead of defining them locally.

**Dependency management:**

* Added missing imports for `os` and `sys` in `pqi_path_helper.py` to support the moved functions.